### PR TITLE
Throw a descriptive error for an invalid breakpoint query

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,15 @@ function getBreakpoints(el) {
     : null;
 
   return breakpoints.split(',')
-    .map(cleanString)
-    .filter(isValidQuery)
+    .map(query => {
+      const cleanedQuery = cleanString(query);
+
+      if (!isValidQuery(cleanedQuery)) {
+        throw new Error('Invalid breakpoint breakpoint defined for breakpoint "' + query + '" on element:\n\n' + el.outerHTML + '\n');
+      }
+
+      return cleanedQuery;
+    })
     .map((query, q) => {
       return {
         query,

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,18 @@ describe('elementBreakpoints', () => {
       expect(el.classList.toString()).to.equal('less-than w-lt-100');
     });
 
+    it('throws an error for an invalid query', () => {
+      elementBreakpoints.unlisten();
+      document.body.innerHTML =`
+        <div class="invalid"
+          data-breakpoints="w = 20"
+        />
+      `;
+
+      expect(elementBreakpoints.listen).to.throw()
+      elementBreakpoints.unlisten();
+    });
+
     it('sets less than or equal', () => {
       const el = document.querySelector('.less-than-equal');
       expect(el.classList.toString()).to.equal('less-than-equal w-lte-100');


### PR DESCRIPTION
Closes #6 

---

This is a proof of concept for the type of descriptive error #6 is describing. The tests won't pass right now and here's what it will take to make this work:

- The `isValidQuery` doesn't catch expressions like `w = 200`, which is technically invalid. There may be others, but it's worth looking into make that more robust.
- I'm not too excited to throw errors from `map()`, so maybe we can think about a better way.

---

Here is an example from the test output of what the error description looks like:

<img width="756" alt="screen shot 2017-08-23 at 4 25 28 pm" src="https://user-images.githubusercontent.com/974723/29636741-cffee948-881f-11e7-8189-e43679c7c507.png">

I think that's pretty descriptive and helpful for debugging a these breakpoints 👍 

--

cc @shanebo 